### PR TITLE
Update origami repo link.

### DIFF
--- a/recipes/origami
+++ b/recipes/origami
@@ -1,1 +1,1 @@
-(origami :repo "jcs-elpa/origami.el" :fetcher github)
+(origami :repo "emacs-origami/origami.el" :fetcher github)


### PR DESCRIPTION
I have moved repository `origami.el` to it's organization. Update the url to the new URL.